### PR TITLE
Fix segment column labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
                         <label class="block mb-1">Data Type</label>
                         <select id="data-type" class="w-full bg-gray-700 text-white p-2 rounded">
                             <option value="trajectory-points">Trajectory Points (route_id, point_id, lat, lon, z)</option>
-                            <option value="trajectory-segments">Trajectory Segments (segment_id, start_x, start_y, end_x, end_y)</option>
+                            <option value="trajectory-segments">Trajectory Segments (segment_id, start_lat, start_lon, end_lat, end_lon)</option>
                             <option value="od-matrix">OD Matrix (points + edges)</option>
                             <option value="ordered-trajectories">Ordered Trajectories</option>
                         </select>


### PR DESCRIPTION
## Summary
- correct segment column labels in dropdown

## Testing
- `npm test` *(fails: Missing script)*