### PR TITLE
Add route height controls and great-circle paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Interactive 3D globe visualization for displaying geographical routes and trajec
 - **Customizable Styling**:
   - Change route colors (single color, by category, or gradient)
   - Adjust line width and opacity
+  - Adjust route height above the globe
   - Toggle and style points
   - Adjust globe atmosphere and lighting
 

--- a/index.html
+++ b/index.html
@@ -172,6 +172,16 @@
                         </div>
                         <p class="text-xs text-gray-400 mt-1">0 = flat lines, higher values create 3D tube-like paths</p>
                     </div>
+
+                    <!-- Route Height -->
+                    <div class="mb-3">
+                        <label class="block mb-1">Route Height</label>
+                        <div class="flex items-center">
+                            <input type="range" id="route-height" min="0" max="2" step="0.05" value="0" class="w-full">
+                            <span id="route-height-value" class="ml-2">0</span>
+                        </div>
+                        <p class="text-xs text-gray-400 mt-1">Raise routes above the surface</p>
+                    </div>
                     
                     <!-- Line Style Options -->
                     <div class="mb-3">

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -135,6 +135,13 @@ class GlobeViewerApp {
             document.getElementById('route-thickness-value').textContent = thickness;
             this.globeManager.updateRouteThickness(thickness);
         });
+
+        // Route height control
+        document.getElementById('route-height').addEventListener('input', (e) => {
+            const h = parseFloat(e.target.value);
+            document.getElementById('route-height-value').textContent = h.toFixed(2);
+            this.globeManager.updateRouteHeight(h);
+        });
         
         // Dash controls
         document.getElementById('dash-size').addEventListener('change', () => {

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -131,6 +131,11 @@ export class UIManager {
         const routeThickness = document.getElementById('route-thickness');
         routeThickness.value = 0;
         document.getElementById('route-thickness-value').textContent = '0';
+
+        // Reset route height
+        const routeHeight = document.getElementById('route-height');
+        routeHeight.value = 0;
+        document.getElementById('route-height-value').textContent = '0';
         
         // Reset point size
         const pointSize = document.getElementById('point-size');
@@ -448,6 +453,10 @@ export class UIManager {
         // 3D thickness
         const thickness = parseFloat(document.getElementById('route-thickness').value);
         this.globeManager.updateRouteThickness(thickness);
+
+        // Route height
+        const routeHeight = parseFloat(document.getElementById('route-height').value);
+        this.globeManager.updateRouteHeight(routeHeight);
         
         // Arc height for OD matrix
         if (this.currentDataType === 'od-matrix') {


### PR DESCRIPTION
## Summary
- introduce routeHeight setting and great-circle path helper
- draw trajectory points, segments and ordered trajectories along great circles
- support tube geometry thickness for all route types
- add route height slider and wiring in UI
- document new Route Height option

## Testing
- `node tests/dataLoader.test.js`