### PR TITLE
Disable dash/arrow styles for thick tubes

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,7 @@
                             <span id="route-thickness-value" class="ml-2">0</span>
                         </div>
                         <p class="text-xs text-gray-400 mt-1">0 = flat lines, higher values create 3D tube-like paths</p>
+                        <p id="thick-style-warning" class="text-xs text-yellow-300 mt-1 hidden">Dashed and arrow styles are disabled for thick lines.</p>
                     </div>
 
                     <!-- Route Height -->

--- a/src/js/globe.js
+++ b/src/js/globe.js
@@ -2050,11 +2050,20 @@ export class GlobeManager {
     
     updateRouteThickness(thickness) {
         console.log(`GlobeManager: Updating route thickness to ${thickness}`);
-        
+
         // Store the previous value
         const previousThickness = this.settings.routes.thickness;
         this.settings.routes.thickness = thickness;
-        
+
+        if (thickness > 0 && (this.settings.routes.style === 'dash' || this.settings.routes.style === 'arrow')) {
+            console.warn('Dashed and arrow styles are not supported for thick lines. Switching to solid.');
+            this.updateLineStyle('solid');
+        }
+
+        if (thickness > 0 && this.settings.routes.style === 'glow') {
+            this.setGlowEffect(true);
+        }
+
         // If thickness changed significantly, we need to recreate geometry
         if (Math.abs(previousThickness - thickness) > 0.01) {
             this.refreshVisualization();
@@ -2563,10 +2572,17 @@ export class GlobeManager {
     }
     
     updateLineStyle(style) {
+        if (this.settings.routes.thickness > 0 && (style === 'dash' || style === 'arrow')) {
+            console.warn('Dashed and arrow styles are not supported for thick lines. Falling back to solid.');
+            style = 'solid';
+        }
+
         this.settings.routes.style = style;
-        
+
         // Enable or disable glow effect
         this.setGlowEffect(style === 'glow');
+
+        this.refreshVisualization();
     }
     
     // Set bloom effect for glowing lines

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -127,12 +127,15 @@ class GlobeViewerApp {
             // Show dash controls only when dash style is selected
             document.getElementById('dash-controls').classList.toggle('hidden', style !== 'dash');
             this.uiManager.updateLineStyle(style);
+            const thick = parseFloat(document.getElementById('route-thickness').value);
+            document.getElementById('thick-style-warning').classList.toggle('hidden', thick === 0);
         });
         
         // Route thickness (3D) control
         document.getElementById('route-thickness').addEventListener('input', (e) => {
             const thickness = parseFloat(e.target.value);
             document.getElementById('route-thickness-value').textContent = thickness;
+            document.getElementById('thick-style-warning').classList.toggle('hidden', thickness === 0);
             this.globeManager.updateRouteThickness(thickness);
         });
 


### PR DESCRIPTION
## Summary
- disable dash and arrow line styles when 3D thickness is non-zero
- warn in console and fallback to solid style
- update event listeners to show a UI warning when thickness > 0
- note in controls that thick lines disable dashed/arrow styles

## Testing
- `node tests/dataLoader.test.js`