### PR TITLE
Add configurable gradient colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
                             <select id="color-variable" class="w-full bg-gray-700 text-white p-2 rounded mb-2">
                                 <!-- Will be populated dynamically -->
                             </select>
-                            
+
                             <label class="block mb-1">Color Ramp</label>
                             <select id="color-ramp" class="w-full bg-gray-700 text-white p-2 rounded mb-2">
                                 <option value="viridis">Viridis</option>
@@ -96,15 +96,7 @@
                                 <option value="red-yellow-green">Red-Yellow-Green</option>
                                 <option value="custom">Custom...</option>
                             </select>
-                            
-                            <div id="custom-ramp-container" class="hidden">
-                                <label class="block mb-1">Start Color</label>
-                                <div id="ramp-start-color" class="color-picker mb-2"></div>
-                                
-                                <label class="block mb-1">End Color</label>
-                                <div id="ramp-end-color" class="color-picker mb-2"></div>
-                            </div>
-                            
+
                             <div class="mt-2">
                                 <label class="block mb-1">Transform</label>
                                 <select id="color-transform" class="w-full bg-gray-700 text-white p-2 rounded mb-2">
@@ -115,6 +107,14 @@
                                     <option value="norm">Normalize (0-1)</option>
                                 </select>
                             </div>
+                        </div>
+
+                        <div id="custom-ramp-container" class="hidden mt-2">
+                            <label class="block mb-1">Start Color</label>
+                            <div id="ramp-start-color" class="color-picker mb-2"></div>
+
+                            <label class="block mb-1">End Color</label>
+                            <div id="ramp-end-color" class="color-picker mb-2"></div>
                         </div>
                     </div>
                     

--- a/src/js/globe.js
+++ b/src/js/globe.js
@@ -2108,7 +2108,7 @@ export class GlobeManager {
         const gradientBox = document.createElement('div');
         gradientBox.style.height = '20px';
         gradientBox.style.width = '100%';
-        gradientBox.style.background = 'linear-gradient(to right, #ff0000, #0000ff)';
+        gradientBox.style.background = `linear-gradient(to right, ${this.settings.routes.customColors.start}, ${this.settings.routes.customColors.end})`;
         gradientBox.style.borderRadius = '2px';
         gradientBox.style.marginBottom = '4px';
         
@@ -2306,8 +2306,8 @@ export class GlobeManager {
             if (this.settings.routes.colorMode === 'gradient') {
                 // Calculate color based on position in sequence
                 const ratio = i / (trajectoryData.length - 1);
-                const startColor = new THREE.Color(0xff0000); // Red
-                const endColor = new THREE.Color(0x0000ff); // Blue
+                const startColor = new THREE.Color(this.settings.routes.customColors.start);
+                const endColor = new THREE.Color(this.settings.routes.customColors.end);
                 segmentColor = new THREE.Color().lerpColors(startColor, endColor, ratio);
             } else if (this.settings.routes.colorMode === 'variable' && this.settings.routes.variable) {
                 let value;
@@ -2819,7 +2819,7 @@ export class GlobeManager {
         
         const gradientBox = document.createElement('div');
         gradientBox.classList.add('gradient-bar');
-        gradientBox.style.background = 'linear-gradient(to right, #ff0000, #0000ff)';
+        gradientBox.style.background = `linear-gradient(to right, ${this.settings.routes.customColors.start}, ${this.settings.routes.customColors.end})`;
         legend.appendChild(gradientBox);
         
         const labels = document.createElement('div');

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -81,7 +81,10 @@ class GlobeViewerApp {
         
         document.getElementById('color-ramp').addEventListener('change', (e) => {
             const isCustom = e.target.value === 'custom';
-            document.getElementById('custom-ramp-container').classList.toggle('hidden', !isCustom);
+            const mode = document.getElementById('color-mode').value;
+            if (mode === 'variable') {
+                document.getElementById('custom-ramp-container').classList.toggle('hidden', !isCustom);
+            }
             this.uiManager.refreshVisualization();
         });
         

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -426,6 +426,12 @@ export class UIManager {
                 const endColor = this.colorPickers.rampEndColorPicker.getColor().toHEXA().toString();
                 this.globeManager.updateCustomColors(startColor, endColor);
             }
+        } else if (colorMode === 'gradient') {
+            if (this.colorPickers) {
+                const startColor = this.colorPickers.rampStartColorPicker.getColor().toHEXA().toString();
+                const endColor = this.colorPickers.rampEndColorPicker.getColor().toHEXA().toString();
+                this.globeManager.updateCustomColors(startColor, endColor);
+            }
         }
         
         // Route width settings
@@ -488,9 +494,22 @@ export class UIManager {
     
     // Update color mode
     updateColorMode(mode) {
-        document.getElementById('single-color-container').classList.toggle('hidden', mode !== 'single');
-        document.getElementById('variable-color-container').classList.toggle('hidden', mode !== 'variable');
-        
+        const singleContainer = document.getElementById('single-color-container');
+        const variableContainer = document.getElementById('variable-color-container');
+        const customRampContainer = document.getElementById('custom-ramp-container');
+
+        singleContainer.classList.toggle('hidden', mode !== 'single');
+        variableContainer.classList.toggle('hidden', mode !== 'variable');
+
+        if (mode === 'gradient') {
+            customRampContainer.classList.remove('hidden');
+        } else if (mode === 'variable') {
+            const ramp = document.getElementById('color-ramp').value;
+            customRampContainer.classList.toggle('hidden', ramp !== 'custom');
+        } else {
+            customRampContainer.classList.add('hidden');
+        }
+
         this.globeManager.updateRouteColorMode(mode);
         this.refreshVisualization();
     }


### PR DESCRIPTION
## Summary
- let color pickers control gradient start and end colors
- expose the gradient pickers outside variable color mode
- use custom colors when rendering ordered trajectories
- update gradient legends to display chosen colors

## Testing
- `node tests/dataLoader.test.js`