### PR TITLE
Use Line2 for wide line rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ The application is built with:
 - Tailwind CSS for styling
 - Vite for bundling
 
+### Browser Support
+Wide line rendering uses Three.js `Line2` which requires WebGL2. If WebGL2 is unavailable, the app falls back to standard thin lines.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- adopt Line2/LineMaterial from three.js for thick route lines
- update all rendering methods to create Line2 when no tube thickness is used
- propagate width changes to LineMaterial
- update line resolutions on resize
- document WebGL2 fallback

## Testing
- `node tests/dataLoader.test.js`