### PR TITLE
Fix build error in MapManager and add build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ The application is built with:
 - Tailwind CSS for styling
 - Vite for bundling
 
+### Building for Production
+To generate a static build with all dependencies bundled, run:
+
+```bash
+bun run build
+# or
+npm run build
+```
+
+The compiled files will be output to the `dist/` directory.
+
 ### Browser Support
 Wide line rendering uses Three.js `Line2` which requires WebGL2. If WebGL2 is unavailable, the app falls back to standard thin lines.
 

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -89,7 +89,7 @@ export class MapManager {
                 layer.setStyle({ dashArray: null });
             }
         });
-
+    }
 
     // New no-op or minimal implementations for UI compatibility
     updateRouteColorMode(mode) {


### PR DESCRIPTION
## Summary
- close missing brace in `MapManager` to fix Vite parsing
- document how to generate a bundled build using bun/npm

## Testing
- `node tests/dataLoader.test.js`
- `npx vite build`